### PR TITLE
fix typo

### DIFF
--- a/website/js/my_contributions.js
+++ b/website/js/my_contributions.js
@@ -82,7 +82,7 @@ function processBatches(arr) {
             commentResult.result.comments
                 .filter(comment =>
                     comment.author &&
-                    (comment.author.emailAddres || comment.author.displayName) &&
+                    (comment.author.emailAddress || comment.author.displayName) &&
                     comment.createdTime
                 )
                 .forEach(comment => {


### PR DESCRIPTION
randomly spotted it. didn't test it or anything. but, hey, it feels good.

`emailAddres` => `emailAddress`

